### PR TITLE
AoT compilation updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 **/*.d.ts
 **/*.js
 **/*.js.map
+/compiled
+*.metadata.json

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ node_modules
 tsconfig.json
 .idea
 **/*.iml
+/compiled

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ node_js:
 
 install:
   - npm install
-  - npm run tsc
+  - npm run build

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { TimeAgoPipe } from './time-ago-pipe';
+
+@NgModule({
+	declarations: [TimeAgoPipe],
+	exports: [TimeAgoPipe],
+})
+export class TimeAgoPipeModule { }
+
+export * from './time-ago-pipe';

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "time-ago-pipe.js",
   "typings": "time-ago-pipe.d.ts",
   "scripts": {
-    "tsc": "tsc",
+    "build": "ngc",
     "test": "mocha --reporter spec"
   },
   "repository": {
@@ -27,7 +27,10 @@
     "node": ">=4.2.4"
   },
   "devDependencies": {
+    "@angular/compiler": "^2.4.5",
+    "@angular/compiler-cli": "^2.4.5",
     "@angular/core": "^2.0.1",
+    "@angular/platform-server": "^2.4.5",
     "@types/core-js": "^0.9.34",
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.41",

--- a/time-ago-pipe.ts
+++ b/time-ago-pipe.ts
@@ -44,7 +44,7 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
 			return months + ' months ago';
 		} else if (days <= 545) {
 			return 'a year ago';
-		} else if (days > 546) {
+		} else { // (days > 545)
 			return years + ' years ago';
 		}
 	}

--- a/time-ago-pipe.ts
+++ b/time-ago-pipe.ts
@@ -18,6 +18,7 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
 					this.ngZone.run(() => this.changeDetectorRef.markForCheck());
 				}, timeToUpdate);
 			}
+			return null;
 		});
 		let minutes = Math.round(Math.abs(seconds / 60));
 		let hours = Math.round(Math.abs(minutes / 60));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,9 @@
     "removeComments": false,
     "noImplicitAny": false
   },
+  "angularCompilerOptions": {
+	"genDir": "compiled"
+  },
   "types":[
     "core-js",
     "node"


### PR DESCRIPTION
Changes needed for AoT compilation. Mostly revolving around using ngc compiler rather than tsc. Also added a module at index.ts or the compiler would complain. This is my first time converting something to use AoT compilation but I followed this guide: https://medium.com/@isaacplmann/getting-your-angular-2-library-ready-for-aot-90d1347bcad#.g1570hrdz

Note: I changed the npm build script from `npm run tsc` to `npm run build` since it's no longer using tsc to compile. If you'd rather use something else that's closer to your conventions I'm fine with that, I'll just push another commit. 