### PR TITLE
added type support for passing date as a number

### DIFF
--- a/time-ago.pipe.ts
+++ b/time-ago.pipe.ts
@@ -8,7 +8,7 @@ export class TimeAgoPipe implements PipeTransform, OnDestroy {
 	constructor(private changeDetectorRef: ChangeDetectorRef, private ngZone: NgZone) {}
 	transform(value:string|number) {
 		this.removeTimer();
-                let d = typeof value === 'string' ? new Date(value) : new Date(value);
+		let d = typeof value === 'string' ? new Date(value) : new Date(value);
 		let now = new Date();
 		let seconds = Math.round(Math.abs((now.getTime() - d.getTime())/1000));
 		let timeToUpdate = (Number.isNaN(seconds)) ? 1000 : this.getSecondsUntilUpdate(seconds) *1000;

--- a/time-ago.pipe.ts
+++ b/time-ago.pipe.ts
@@ -6,9 +6,9 @@ import {Pipe, PipeTransform, NgZone, ChangeDetectorRef, OnDestroy} from "@angula
 export class TimeAgoPipe implements PipeTransform, OnDestroy {
 	private timer: number;
 	constructor(private changeDetectorRef: ChangeDetectorRef, private ngZone: NgZone) {}
-	transform(value:string) {
+	transform(value:string|number) {
 		this.removeTimer();
-		let d = new Date(value);
+                let d = typeof value === 'string' ? new Date(value) : new Date(value);
 		let now = new Date();
 		let seconds = Math.round(Math.abs((now.getTime() - d.getTime())/1000));
 		let timeToUpdate = (Number.isNaN(seconds)) ? 1000 : this.getSecondsUntilUpdate(seconds) *1000;


### PR DESCRIPTION
This fix is needed for IDEs to not complain about type mismatch, e.g. in cases such as 

`{{ item.modifiedDate | timeAgo }}`

in case modified date is a number. 

It works in practice because Date has a constructor that accepts number (milliseconds time stamp), but some IDEAs will complain about the pipe accepting only strings where the attribute is a number.

note: the ? condition seems redundant, but needed for typescript type guard to work. otherwise (at least in TS 2.7.2) it doesn't know to pick the right Date constructor based on the type of value 
